### PR TITLE
Add dashloader support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,7 @@ minecraft {
 }
 
 repositories {
+    mavenCentral()
     maven {
         url "https://oskarstrom.net/maven"
     }
@@ -26,7 +27,7 @@ dependencies {
     modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
 
 
-	modImplementation 'net.oskarstrom:DashLoader:2.0-pre2'
+	modImplementation 'net.oskarstrom:DashLoader:2.1-dev3'
 	modImplementation("net.fabricmc.fabric-api:fabric-api:${project.fabric_version}") {
         exclude module: "fabric-loader"
         exclude group: "net.fabricmc"

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
-	id 'fabric-loom' version '0.8-SNAPSHOT'
-	id 'maven-publish'
+    id 'fabric-loom' version '0.8-SNAPSHOT'
+    id 'maven-publish'
 }
 
 sourceCompatibility = JavaVersion.VERSION_1_8
@@ -13,72 +13,80 @@ group = project.maven_group
 minecraft {
 }
 
-dependencies {
-	//to change the versions see the gradle.properties file
-	minecraft "com.mojang:minecraft:${project.minecraft_version}"
-	mappings "net.fabricmc:yarn:${project.yarn_mappings}:v2"
-	modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
+repositories {
+    maven {
+        url "https://oskarstrom.net/maven"
+    }
+}
 
-	modImplementation ("net.fabricmc.fabric-api:fabric-api:${project.fabric_version}") {
-		exclude module: "fabric-loader"
-		exclude group: "net.fabricmc"
-	}
+dependencies {
+    //to change the versions see the gradle.properties file
+    minecraft "com.mojang:minecraft:${project.minecraft_version}"
+    mappings "net.fabricmc:yarn:${project.yarn_mappings}:v2"
+    modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
+
+
+	modImplementation 'net.oskarstrom:DashLoader:2.0-pre2'
+	modImplementation("net.fabricmc.fabric-api:fabric-api:${project.fabric_version}") {
+        exclude module: "fabric-loader"
+        exclude group: "net.fabricmc"
+    }
 }
 
 processResources {
-	inputs.property "version", project.version
+    inputs.property "version", project.version
 
-	filesMatching("fabric.mod.json") {
-		expand "version": project.version
-	}
+    filesMatching("fabric.mod.json") {
+        expand "version": project.version
+    }
 }
 
 tasks.withType(JavaCompile).configureEach {
-	// ensure that the encoding is set to UTF-8, no matter what the system default is
-	// this fixes some edge cases with special characters not displaying correctly
-	// see http://yodaconditions.net/blog/fix-for-java-file-encoding-problems-with-gradle.html
-	// If Javadoc is generated, this must be specified in that task too.
-	it.options.encoding = "UTF-8"
+    // ensure that the encoding is set to UTF-8, no matter what the system default is
+    // this fixes some edge cases with special characters not displaying correctly
+    // see http://yodaconditions.net/blog/fix-for-java-file-encoding-problems-with-gradle.html
+    // If Javadoc is generated, this must be specified in that task too.
+    it.options.encoding = "UTF-8"
 
-	// The Minecraft launcher currently installs Java 8 for users, so your mod probably wants to target Java 8 too
-	// JDK 9 introduced a new way of specifying this that will make sure no newer classes or methods are used.
-	// We'll use that if it's available, but otherwise we'll use the older option.
-	def targetVersion = 8
-	if (JavaVersion.current().isJava9Compatible()) {
-		it.options.release = targetVersion
-	}
+    // The Minecraft launcher currently installs Java 8 for users, so your mod probably wants to target Java 8 too
+    // JDK 9 introduced a new way of specifying this that will make sure no newer classes or methods are used.
+    // We'll use that if it's available, but otherwise we'll use the older option.
+    def targetVersion = 8
+    if (JavaVersion.current().isJava9Compatible()) {
+        it.options.release = targetVersion
+    }
 }
 
 java {
-	// Loom will automatically attach sourcesJar to a RemapSourcesJar task and to the "build" task
-	// if it is present.
-	// If you remove this line, sources will not be generated.
-	withSourcesJar()
+    // Loom will automatically attach sourcesJar to a RemapSourcesJar task and to the "build" task
+    // if it is present.
+    // If you remove this line, sources will not be generated.
+    withSourcesJar()
 }
 
 jar {
-	from("LICENSE") {
-		rename { "${it}_${project.archivesBaseName}"}
-	}
+    from("LICENSE") {
+        rename { "${it}_${project.archivesBaseName}" }
+    }
 }
 
 // configure the maven publication
 publishing {
-	publications {
-		mavenJava(MavenPublication) {
-			// add all the jars that should be included when publishing to maven
-			artifact(jar) {
-				builtBy remapJar
-			}
-			artifact(sourcesJar) {
-				builtBy remapSourcesJar
-			}
-		}
-	}
+    publications {
+        mavenJava(MavenPublication) {
+            // add all the jars that should be included when publishing to maven
+            artifact(jar) {
+                builtBy remapJar
+            }
+            artifact(sourcesJar) {
+                builtBy remapSourcesJar
+            }
+        }
+    }
 
-	// select the repositories you want to publish to
-	repositories {
-		// uncomment to publish to the local maven
-		// mavenLocal()
-	}
+    // select the repositories you want to publish to
+    repositories {
+        // uncomment to publish to the local maven
+        // mavenLocal()
+    }
 }

--- a/src/main/java/io/github/nuclearfarts/cbt/compat/dashloader/DashCBTBakedModel.java
+++ b/src/main/java/io/github/nuclearfarts/cbt/compat/dashloader/DashCBTBakedModel.java
@@ -1,8 +1,6 @@
 package io.github.nuclearfarts.cbt.compat.dashloader;
 
 import com.mojang.datafixers.util.Pair;
-import io.activej.serializer.annotations.Deserialize;
-import io.activej.serializer.annotations.Serialize;
 import io.github.nuclearfarts.cbt.config.CTMConfig;
 import io.github.nuclearfarts.cbt.model.CBTBakedModel;
 import io.github.nuclearfarts.cbt.sprite.SpriteProvider;

--- a/src/main/java/io/github/nuclearfarts/cbt/compat/dashloader/DashCBTBakedModel.java
+++ b/src/main/java/io/github/nuclearfarts/cbt/compat/dashloader/DashCBTBakedModel.java
@@ -1,0 +1,114 @@
+package io.github.nuclearfarts.cbt.compat.dashloader;
+
+import com.mojang.datafixers.util.Pair;
+import io.activej.serializer.annotations.Deserialize;
+import io.activej.serializer.annotations.Serialize;
+import io.github.nuclearfarts.cbt.config.CTMConfig;
+import io.github.nuclearfarts.cbt.model.CBTBakedModel;
+import io.github.nuclearfarts.cbt.sprite.SpriteProvider;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.texture.Sprite;
+import net.minecraft.resource.Resource;
+import net.minecraft.resource.ResourceManager;
+import net.minecraft.util.Identifier;
+import net.oskarstrom.dashloader.DashRegistry;
+import net.oskarstrom.dashloader.api.annotation.DashObject;
+import net.oskarstrom.dashloader.model.DashModel;
+import org.apache.commons.io.IOUtils;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.*;
+
+@DashObject(CBTBakedModel.class)
+public class DashCBTBakedModel implements DashModel {
+    @Serialize(order = 0)
+    public final int model;
+    @Serialize(order = 1)
+    public final Map<int[], TriPair> spriteProviders;
+
+    public DashCBTBakedModel(@Deserialize("model") int model,
+                             @Deserialize("spriteProviders") Map<int[], TriPair> spriteProviders) {
+        this.model = model;
+        this.spriteProviders = spriteProviders;
+    }
+
+    public DashCBTBakedModel(CBTBakedModel cbtBakedModel, DashRegistry registry) {
+        final ResourceManager manager = MinecraftClient.getInstance().getResourceManager();
+        this.model = registry.createModelPointer(cbtBakedModel.getWrapped());
+        final List<Pair<Sprite[], CTMConfig>> pairs = DashloaderData.sprites.get(cbtBakedModel);
+        this.spriteProviders = new HashMap<>();
+        pairs.forEach(pair -> {
+            final Sprite[] sprites = pair.getFirst();
+            final int[] spritePointers = new int[sprites.length];
+            for (int i = 0; i < sprites.length; i++) {
+                spritePointers[i] = registry.createSpritePointer(sprites[i]);
+            }
+            try {
+                final Identifier id = DashloaderData.configLocations.get(pair.getSecond());
+                final Resource resource = manager.getResource(id);
+                final InputStream inputStream = resource.getInputStream();
+                final byte[] bytes = IOUtils.toByteArray(inputStream);
+                this.spriteProviders.put(spritePointers, new TriPair(bytes, resource.getResourcePackName(), registry.createIdentifierPointer(id)));
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        });
+    }
+
+    @Override
+    public CBTBakedModel toUndash(DashRegistry registry) {
+        try {
+            List<SpriteProvider> spriteProviders = new ArrayList<>();
+            final ResourceManager manager = MinecraftClient.getInstance().getResourceManager();
+            this.spriteProviders.entrySet().forEach(entry -> {
+                final int[] spritePointers = entry.getKey();
+                final TriPair info = entry.getValue();
+                final Sprite[] sprites = new Sprite[spritePointers.length];
+                for (int i = 0; i < spritePointers.length; i++) {
+                    sprites[i] = registry.getSprite(spritePointers[i]);
+                }
+                Identifier configLocation = registry.getIdentifier(info.configLocation);
+                try {
+                    Properties properties = new Properties();
+                    properties.load(new ByteArrayInputStream(info.bytes));
+                    final CTMConfig config = CTMConfig.load(properties, configLocation, manager, info.resourcePackName);
+                    spriteProviders.add(config.createSpriteProvider(sprites));
+                } catch (IOException e) {
+                    e.printStackTrace();
+                }
+
+            });
+            return new CBTBakedModel(registry.getModel(model), spriteProviders.toArray(new SpriteProvider[spriteProviders.size()]));
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        System.out.println("null");
+        return null;
+    }
+
+    @Override
+    public int getStage() {
+        return 3;
+    }
+
+
+    public static class TriPair {
+        @Serialize(order = 0)
+        public byte[] bytes;
+        @Serialize(order = 1)
+        public String resourcePackName;
+        @Serialize(order = 2)
+        public int configLocation;
+
+
+        public TriPair(@Deserialize("bytes") byte[] bytes,
+                       @Deserialize("resourcePackName") String resourcePackName,
+                       @Deserialize("configLocation") int configLocation) {
+            this.bytes = bytes;
+            this.resourcePackName = resourcePackName;
+            this.configLocation = configLocation;
+        }
+    }
+}

--- a/src/main/java/io/github/nuclearfarts/cbt/compat/dashloader/DashloaderData.java
+++ b/src/main/java/io/github/nuclearfarts/cbt/compat/dashloader/DashloaderData.java
@@ -1,0 +1,17 @@
+package io.github.nuclearfarts.cbt.compat.dashloader;
+
+import com.mojang.datafixers.util.Pair;
+import io.github.nuclearfarts.cbt.config.CTMConfig;
+import net.minecraft.client.render.model.BakedModel;
+import net.minecraft.client.texture.Sprite;
+import net.minecraft.util.Identifier;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class DashloaderData {
+    public static Map<BakedModel,List<Pair<Sprite[],CTMConfig>>> sprites = new HashMap<>();
+    public static Map<CTMConfig, Identifier> configLocations = new HashMap<>();
+
+}

--- a/src/main/java/io/github/nuclearfarts/cbt/config/CTMConfig.java
+++ b/src/main/java/io/github/nuclearfarts/cbt/config/CTMConfig.java
@@ -9,6 +9,7 @@ import java.util.function.BiPredicate;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 
+import io.github.nuclearfarts.cbt.compat.dashloader.DashloaderData;
 import net.minecraft.client.texture.Sprite;
 import net.minecraft.client.util.ModelIdentifier;
 import net.minecraft.client.util.SpriteIdentifier;
@@ -32,11 +33,11 @@ public interface CTMConfig extends Comparable<CTMConfig> {
 	int getResourcePackPriority();
 	int getWeight();
 	String getFileName();
-	
+
 	static void registerConfigLoader(String formatName, Loader<?> loader) {
 		PrivateConstants.CTM_CONFIG_LOADERS.put(formatName, loader);
 	}
-	
+
 	static CTMConfig load(Properties properties, Identifier location, ResourceManager manager, String packName) throws IOException {
 		Loader<?> loader;
 		if((loader = PrivateConstants.CTM_CONFIG_LOADERS.get(properties.getProperty("method"))) != null) {
@@ -44,19 +45,21 @@ public interface CTMConfig extends Comparable<CTMConfig> {
 		}
 		throw new IllegalArgumentException("Invalid or unsupported CTM method " + properties.getProperty("method"));
 	}
-	
+
 	static CTMConfig load(Identifier propertiesLocation, ResourceManager manager) throws IOException {
 		Properties properties = new Properties();
 		Resource resource = manager.getResource(propertiesLocation);
 		properties.load(resource.getInputStream());
-		return CTMConfig.load(properties, propertiesLocation, manager, resource.getResourcePackName());
+		final CTMConfig configOut = CTMConfig.load(properties, propertiesLocation, manager, resource.getResourcePackName());
+		DashloaderData.configLocations.put(configOut, propertiesLocation);
+		return configOut;
 	}
 
 	@FunctionalInterface
 	public interface Loader<T extends CTMConfig> {
 		T load(Properties properties, Identifier location, ResourceManager manager, String packName) throws IOException;
 	}
-	
+
 	public static final class PrivateConstants {
 		private PrivateConstants() { }
 		private static final Map<String, Loader<?>> CTM_CONFIG_LOADERS = new HashMap<>();

--- a/src/main/java/io/github/nuclearfarts/cbt/mixin/ReloadableResourceManagerImplMixin.java
+++ b/src/main/java/io/github/nuclearfarts/cbt/mixin/ReloadableResourceManagerImplMixin.java
@@ -26,7 +26,6 @@ public abstract class ReloadableResourceManagerImplMixin implements ReloadableRe
 
 	@Inject(method = "reload", at = @At(value = "INVOKE",target = "Ljava/util/List;iterator()Ljava/util/Iterator;", shift = At.Shift.AFTER))
 	private void injectCBTPack(Executor prepareExecutor, Executor applyExecutor, CompletableFuture<Unit> initialStage, List<ResourcePack> packs, CallbackInfoReturnable<ResourceReload> cir) {
-		System.out.println("reload");
 		ConnectedBlockTextures.RESOURCE_PACK_PRIORITY_MAP.clear();
 		for(int i = 0; i < packs.size(); i++) {
 			ConnectedBlockTextures.RESOURCE_PACK_PRIORITY_MAP.put(packs.get(i).getName(), i);

--- a/src/main/java/io/github/nuclearfarts/cbt/mixin/ReloadableResourceManagerImplMixin.java
+++ b/src/main/java/io/github/nuclearfarts/cbt/mixin/ReloadableResourceManagerImplMixin.java
@@ -24,8 +24,9 @@ public abstract class ReloadableResourceManagerImplMixin implements ReloadableRe
 	@Shadow
 	public abstract void addPack(ResourcePack resourcePack);
 
-	@Inject(method = "reload", at = @At(value = "RETURN", shift = At.Shift.BEFORE))
+	@Inject(method = "reload", at = @At(value = "INVOKE",target = "Ljava/util/List;iterator()Ljava/util/Iterator;", shift = At.Shift.AFTER))
 	private void injectCBTPack(Executor prepareExecutor, Executor applyExecutor, CompletableFuture<Unit> initialStage, List<ResourcePack> packs, CallbackInfoReturnable<ResourceReload> cir) {
+		System.out.println("reload");
 		ConnectedBlockTextures.RESOURCE_PACK_PRIORITY_MAP.clear();
 		for(int i = 0; i < packs.size(); i++) {
 			ConnectedBlockTextures.RESOURCE_PACK_PRIORITY_MAP.put(packs.get(i).getName(), i);

--- a/src/main/java/io/github/nuclearfarts/cbt/model/CBTBakedModel.java
+++ b/src/main/java/io/github/nuclearfarts/cbt/model/CBTBakedModel.java
@@ -33,7 +33,11 @@ public class CBTBakedModel extends ForwardingBakedModel {
 	public boolean isVanillaAdapter() {
 		return false;
 	}
-	
+
+	public BakedModel getWrapped() {
+		return wrapped;
+	}
+
 	@Override
 	public void emitBlockQuads(BlockRenderView blockView, BlockState state, BlockPos pos, Supplier<Random> randomSupplier, RenderContext context) {
 		SpriteFinder spriteFinder = SpriteFinder.get(MinecraftClient.getInstance().getBakedModelManager().getAtlas(SpriteAtlasTexture.BLOCK_ATLAS_TEXTURE));

--- a/src/main/java/io/github/nuclearfarts/cbt/model/CBTUnbakedModel.java
+++ b/src/main/java/io/github/nuclearfarts/cbt/model/CBTUnbakedModel.java
@@ -8,6 +8,7 @@ import java.util.Set;
 import java.util.function.Function;
 import com.mojang.datafixers.util.Pair;
 
+import io.github.nuclearfarts.cbt.compat.dashloader.DashloaderData;
 import net.minecraft.client.render.model.BakedModel;
 import net.minecraft.client.render.model.ModelBakeSettings;
 import net.minecraft.client.render.model.ModelLoader;
@@ -48,10 +49,15 @@ public class CBTUnbakedModel implements UnbakedModel {
 	public BakedModel bake(ModelLoader loader, Function<SpriteIdentifier, Sprite> textureGetter, ModelBakeSettings rotationContainer, Identifier modelId) {
 		try {
 			List<SpriteProvider> spriteProviders = new ArrayList<>();
+			List<Pair<Sprite[],CTMConfig>> spritesOut = new ArrayList<>();
 			for(CTMConfig config : configs) {
-				spriteProviders.add(config.createSpriteProvider(config.getTileProvider().load(textureGetter)));
+				final Sprite[] sprites = config.getTileProvider().load(textureGetter);
+				spritesOut.add(Pair.of(sprites,config));
+				spriteProviders.add(config.createSpriteProvider(sprites));
 			}
-			return new CBTBakedModel(baseModel.bake(loader, textureGetter, rotationContainer, modelId), spriteProviders.toArray(new SpriteProvider[spriteProviders.size()]));
+			final CBTBakedModel cbtBakedModel = new CBTBakedModel(baseModel.bake(loader, textureGetter, rotationContainer, modelId), spriteProviders.toArray(new SpriteProvider[spriteProviders.size()]));
+			DashloaderData.sprites.put(cbtBakedModel,spritesOut);
+			return cbtBakedModel;
 		} catch (Exception e) {
 			e.printStackTrace();
 			return null;

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -2,7 +2,6 @@
   "schemaVersion": 1,
   "id": "connected_block_textures",
   "version": "${version}",
-
   "name": "Connected Block Textures",
   "description": "Support for MCPatcher/Optifine-format connected textures.",
   "authors": [
@@ -11,7 +10,6 @@
   "contact": {
     "sources": "https://github.com/Nuclearfarts/connected-block-textures"
   },
-
   "license": "LGPLv3",
   "icon": "assets/connected_block_textures/icon.png",
   "environment": "client",
@@ -23,7 +21,11 @@
   "mixins": [
     "connected_block_textures.mixins.json"
   ],
-
+  "custom": {
+    "dashloader:customobject": [
+      "io.github.nuclearfarts.cbt.compat.dashloader.DashCBTBakedModel"
+    ]
+  },
   "depends": {
     "fabricloader": ">=0.4.0",
     "fabric": "*"


### PR DESCRIPTION
The code here is not the cleanest that is possible but it is made with the intention of changing as little as possible to avoid merge conflicts. The only real change here is that the reloadable ResourceManager gets injected slightly earlier so that dashloader does not init before the assets are available.